### PR TITLE
updated #24 issue

### DIFF
--- a/src/components/product/index.js
+++ b/src/components/product/index.js
@@ -174,7 +174,8 @@ const Product = (props) => {
           <div className="info">
             <span className="d-block catName">{productData.brand}</span>
             <h4 className="title">
-              <Link>{productData.productName.substr(0, 50) + "..."}</Link>
+              {/* <Link>{productData.productName.substr(0, 50) + "..."}</Link> */}
+              <Link>{productData.productName.substr(0, 30) + "..."}</Link>
             </h4>
             <Rating
               name="half-rating-read"

--- a/src/components/product/style.css
+++ b/src/components/product/style.css
@@ -1,4 +1,4 @@
-.productThumb{width: 100%; height: auto;  border: 1px solid rgba(0,0,0,0.1); overflow: hidden; border-radius: 15px; padding:25px; transition: all 0.3s ease-in-out; position: relative;}
+.productThumb{width: 100%; height: auto;  border: 1px solid rgba(0,0,0,0.1); overflow: hidden; border-radius: 15px; padding:25px; transition: all 0.3s ease-in-out; position: relative;   box-shadow:0 4px 8px 0 rgba(0, 0, 0, 0.05), 0 6px 20px 0 rgba(0, 0, 0, 0.04);}
 
 .productThumb .badge{position: absolute; top: 0px; left: 0px; display: inline-block;
 background: red; z-index: 10; color: #fff; padding: 10px 25px; font-size: 16px;


### PR DESCRIPTION
the card size are not-uniform and it could be unifrom throughout the page refered to issue #24 

## Description
the opacity of the card were not to much visible an d were not uniform in the site.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

1) tested from an existing user at local host.
2) tested from a non-existing user at local host
for screen: 15.5 inches

## Screenshots (if appropriate):
![Screenshot 2024-06-04 112550](https://github.com/MAVRICK-1/Nest-Ondc/assets/96661387/607fb809-5945-40ef-8025-46ae317c3e0e)

## Types of changes

2 things updated:
1) Displayed substring is reduced to make the siuze of the card uniform throughout the entire page
2) added the shadow-box event on css to increase the opacity of each card present

## Checklist:

- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.