### PR TITLE
Redirection in Related Products Page

### DIFF
--- a/src/pages/Details/index.js
+++ b/src/pages/Details/index.js
@@ -186,7 +186,7 @@ const DetailsPage = (props) => {
     fetchWishlistProducts();
 
     setIsLoading(false);
-  }, []);
+  },[currentProduct]);
 
   useEffect(() => {
     // //console.log(currentProduct); // Log currentProduct after it has been updated
@@ -944,7 +944,9 @@ const DetailsPage = (props) => {
                 relatedProducts.map((product, index) => {
                   return (
                     <div className="item" key={index}>
-                      <Product tag={product.type} item={product} />
+                      <Button onClick={()=>{setCurrentProduct(product)}}>
+                        <Product tag={product.type} item={product} />
+                      </Button>
                     </div>
                   );
                 })}


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Adding Redirection in Related Products Page which Closes https://github.com/MAVRICK-1/Nest-Ondc/issues/76
<br>
So I used UseState functionality and changes in the useEffect to make these appropriate changes for re-rendering the page upon state change.

## Motivation and Context

This was a problem since only products were displaying and there wasn't any click feature or redirection available in them. So this problem had to be rectified.

## Screenshots (if appropriate):
https://github.com/MAVRICK-1/Nest-Ondc/assets/84094715/fc9a8106-12be-4be0-a027-69989d125c6f

As we can see in the above video the redirection is happening perfectly.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.